### PR TITLE
Update linter configuration

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -17,16 +17,22 @@
     "airbnb-typescript",
     "plugin:@typescript-eslint/recommended",
     "plugin:react/recommended",
-    "plugin:react-hooks/recommended"
+    "plugin:react-hooks/recommended",
+    "plugin:react/jsx-runtime"
   ],
   "rules": {
+    "key-spacing": "off",
     "@typescript-eslint/key-spacing": "error",
+    "no-unused-vars": "off",
+    "@typescript-eslint/no-unused-vars": "error",
     "@typescript-eslint/type-annotation-spacing": "error",
     "eol-last": "error",
+    "indent": ["error", 2],
     "no-multi-spaces": "error",
+    "no-trailing-spaces": "error",
     "padding-line-between-statements": [
       "error",
-      { "blankLine": "always", "prev": "block-like", "next": "block-like" }
+      { "blankLine": "always", "prev": "function", "next": "function" }
     ],
     "react/jsx-closing-bracket-location": "error",
     "react/jsx-closing-tag-location": "error",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import { useEffect } from 'react';
 import Dashboard from './pages/dashboard';
 import { SocketClient, SessionStorage, LruStorage } from './client';
 import { ClientContext } from './client-context';

--- a/src/client/lru-storage.ts
+++ b/src/client/lru-storage.ts
@@ -27,12 +27,12 @@ export class LruStorage implements Storage {
 
   setItem(key: string, value: string): void {
     const newItemSize = key.length + value.length;
-    
+
     if (newItemSize > this.maxBytes) {
       console.log(`[LruStorage] Trying to insert an item that is too large (${newItemSize}), skipping`);
       return;
     }
-    
+
     this.removeItem(key);
 
     while (this.bytesUsed + newItemSize > this.maxBytes) {

--- a/src/client/socket-client.ts
+++ b/src/client/socket-client.ts
@@ -11,7 +11,7 @@ class CounterMap {
   private set(key: string, value: number) {
     this.counters.set(key, value);
     return value;
-  } 
+  }
 
   increment(key: string) {
     return this.set(key, this.get(key) + 1);
@@ -28,9 +28,9 @@ class CounterMap {
 
 class MaxMap {
   private readonly defaultValue: number;
-  
+
   private readonly cacheLimits = new Map<string, number>();
-  
+
   constructor(defaultValue: number) {
     this.defaultValue = defaultValue;
   }

--- a/src/components/chart/index.tsx
+++ b/src/components/chart/index.tsx
@@ -1,4 +1,4 @@
-import React, { forwardRef } from 'react';
+import { forwardRef } from 'react';
 import { ChartOptions, DeepPartial, IChartApi } from 'lightweight-charts';
 import { useDesignToken } from '../../hooks/use-design-token';
 import RawChart from './raw-chart';

--- a/src/components/chart/raw-chart.tsx
+++ b/src/components/chart/raw-chart.tsx
@@ -1,4 +1,4 @@
-import React, {
+import {
   forwardRef,
   useEffect,
   useImperativeHandle,

--- a/src/components/empty-state/index.tsx
+++ b/src/components/empty-state/index.tsx
@@ -1,13 +1,13 @@
-import React from 'react';
+import { ReactNode } from 'react';
 import { Box, SpaceBetween } from '@cloudscape-design/components';
 import styles from './styles.module.scss';
 
 interface EmptyStateProps {
-  icon?: React.ReactNode;
+  icon?: ReactNode;
   title: string;
   verticalCenter?: boolean;
   description: string;
-  action?: React.ReactNode;
+  action?: ReactNode;
 }
 
 export function EmptyState({ title, description, action, verticalCenter }: EmptyStateProps) {

--- a/src/components/sidebar/add-dashboard-button.tsx
+++ b/src/components/sidebar/add-dashboard-button.tsx
@@ -1,10 +1,10 @@
-import React, { MouseEventHandler } from 'react';
+import { MouseEventHandler } from 'react';
 
 function PlusButton(props: { onClick: MouseEventHandler }) {
   return (
-        <button className='plus-button' onClick={props.onClick}>
-            +
-        </button>
+    <button className='plus-button' onClick={props.onClick}>
+      +
+    </button>
   );
 }
 

--- a/src/components/sidebar/index.tsx
+++ b/src/components/sidebar/index.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import { useState } from 'react';
 import SideNavigation from '@cloudscape-design/components/side-navigation';
 import { useNavigate } from 'react-router-dom';
 import PlusButton from './add-dashboard-button';
@@ -17,8 +17,8 @@ function getDashboardIdsFromLocalStorage(): ReadonlyArray<number> {
 }
 
 function Sidebar() {
-  const [dashboards, setDashboards] = React.useState(getDashboardIdsFromLocalStorage());
-  const [activeHref, setActiveHref] = React.useState('');
+  const [dashboards, setDashboards] = useState(getDashboardIdsFromLocalStorage());
+  const [activeHref, setActiveHref] = useState('');
   const navigate = useNavigate();
 
   const addDashboard = () => {

--- a/src/components/sidebar/remove-dashboard-button.tsx
+++ b/src/components/sidebar/remove-dashboard-button.tsx
@@ -1,8 +1,8 @@
-import React, { MouseEventHandler } from 'react';
+import { MouseEventHandler } from 'react';
 
 function RemoveButton(props: { onClick: MouseEventHandler }) {
   return (
-      <button className='remove-button' onClick={props.onClick} />
+    <button className='remove-button' onClick={props.onClick} />
   );
 }
 export default RemoveButton;

--- a/src/components/ticker-searchbar/ticker-searchbar.tsx
+++ b/src/components/ticker-searchbar/ticker-searchbar.tsx
@@ -1,11 +1,11 @@
-import * as React from 'react';
+import { useState } from 'react';
 import Autosuggest from '@cloudscape-design/components/autosuggest';
 import { useNavigate } from 'react-router-dom';
 import data from './sp500-companies.json';
 
 
 function TickerSearchbar() {
-  const [value, setValue] = React.useState('');
+  const [value, setValue] = useState('');
   const navigate = useNavigate();
   return (
     <Autosuggest

--- a/src/components/topbar.tsx
+++ b/src/components/topbar.tsx
@@ -1,4 +1,3 @@
-import * as React from 'react';
 import TopNavigation from '@cloudscape-design/components/top-navigation';
 import TickerSearchbar from './ticker-searchbar/ticker-searchbar';
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import { StrictMode } from 'react';
 import ReactDOM from 'react-dom/client';
 import App from './App';
 import '@cloudscape-design/global-styles/index.css';
@@ -8,7 +8,7 @@ const root = ReactDOM.createRoot(
 );
 
 root.render(
-  <React.StrictMode>
+  <StrictMode>
     <App />
-  </React.StrictMode>,
+  </StrictMode>,
 );

--- a/src/pages/dashboard/components/configurable-widget.tsx
+++ b/src/pages/dashboard/components/configurable-widget.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import { Fragment } from 'react';
 import ButtonDropdown from '@cloudscape-design/components/button-dropdown';
 import BoardItem from '@cloudscape-design/board-components/board-item';
 import { WidgetDataType } from '../widgets/interfaces';
@@ -11,7 +11,7 @@ interface ConfigurableWidgetProps {
 }
 
 export function ConfigurableWidget({ config, onRemove }: ConfigurableWidgetProps) {
-  const Wrapper = config.provider ?? React.Fragment;
+  const Wrapper = config.provider ?? Fragment;
   return (
     <Wrapper>
       <BoardItem

--- a/src/pages/dashboard/components/palette-item.tsx
+++ b/src/pages/dashboard/components/palette-item.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import Header from '@cloudscape-design/components/header';
 import BoardItem from '@cloudscape-design/board-components/board-item';
 import Box from '@cloudscape-design/components/box';

--- a/src/pages/dashboard/components/palette.tsx
+++ b/src/pages/dashboard/components/palette.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { Button, SpaceBetween, TextFilter } from '@cloudscape-design/components';
 import ItemsPalette, { ItemsPaletteProps } from '@cloudscape-design/board-components/items-palette';
 import { useCollection } from '@cloudscape-design/collection-hooks';

--- a/src/pages/dashboard/index.tsx
+++ b/src/pages/dashboard/index.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import { useState } from 'react';
 import {
   AppLayout,
   BreadcrumbGroup,
@@ -31,84 +31,85 @@ function DashboardContent( props: { dashboardId: string } ) {
   const [splitPanelSize, setSplitPanelSize] = useState(splitPanelMaxSize);
 
   return (
-      <AppLayout
-          contentType="dashboard"
-          breadcrumbs={<BreadcrumbGroup
-              items={[
-                { text: 'App', href: '/' },
-                { text: `Dashboard ${dashboardId}`, href: '#/' },
-              ]}
-              expandAriaLabel="Show path"
-              ariaLabel="Breadcrumbs"
-                       />}
-          navigationHide={true}
-          toolsHide={true}
-          content={
-              <ContentLayout
-                  header={
-                      <Header
-                          variant="h1"
-                          actions={
-                              <SpaceBetween size="xs" direction="horizontal">
-                                  <Button iconName="add-plus" onClick={() => setSplitPanelOpen(true)}>
-                                      Add widget
-                                  </Button>
-                              </SpaceBetween>
-                          }
-                      >
-                          Dashboard {dashboardId}
-                      </Header>
-                  }
-              >
-                  <Board
-                      empty={
-                          <EmptyState
-                              title="No widgets"
-                              description="There are no widgets on the dashboard."
-                              verticalCenter={true}
-                              action={
-                                  <Button iconName="add-plus" onClick={() => setSplitPanelOpen(true)}>
-                                      Add widget
-                                  </Button>
-                              }
-                          />
-                      }
-                      i18nStrings={boardI18nStrings}
-                      items={getBoardWidgets(layout)}
-                      onItemsChange={({ detail }) => {
-                        setLayout(exportLayout(detail.items));
-                      }}
-                      renderItem={(item, actions) => (
-                          <ConfigurableWidget config={item.data} onRemove={actions.removeItem} />
-                      )}
-                  />
-              </ContentLayout>
+    <AppLayout
+      contentType="dashboard"
+      breadcrumbs={
+        <BreadcrumbGroup
+          items={[
+            { text: 'App', href: '/' },
+            { text: `Dashboard ${dashboardId}`, href: '#/' },
+          ]}
+          expandAriaLabel="Show path"
+          ariaLabel="Breadcrumbs"
+        />}
+      navigationHide={true}
+      toolsHide={true}
+      content={
+        <ContentLayout
+          header={
+            <Header
+              variant="h1"
+              actions={
+                <SpaceBetween size="xs" direction="horizontal">
+                  <Button iconName="add-plus" onClick={() => setSplitPanelOpen(true)}>
+                    Add widget
+                  </Button>
+                </SpaceBetween>
+              }
+            >
+              Dashboard {dashboardId}
+            </Header>
           }
-          splitPanel={
-              <SplitPanel
-                  header="Add widgets"
-                  closeBehavior="hide"
-                  hidePreferencesButton={true}
-                  i18nStrings={splitPanelI18nStrings}
-              >
-                  <Palette items={getPaletteWidgets(layout)} />
-              </SplitPanel>
-          }
-          splitPanelPreferences={{ position: 'side' }}
-          splitPanelOpen={splitPanelOpen}
-          onSplitPanelToggle={({ detail }) => setSplitPanelOpen(detail.open)}
-          splitPanelSize={splitPanelSize}
-          onSplitPanelResize={event => setSplitPanelSize(Math.min(event.detail.size, splitPanelMaxSize))}
-      />
+        >
+          <Board
+            empty={
+              <EmptyState
+                title="No widgets"
+                description="There are no widgets on the dashboard."
+                verticalCenter={true}
+                action={
+                  <Button iconName="add-plus" onClick={() => setSplitPanelOpen(true)}>
+                    Add widget
+                  </Button>
+                }
+              />
+            }
+            i18nStrings={boardI18nStrings}
+            items={getBoardWidgets(layout)}
+            onItemsChange={({ detail }) => {
+              setLayout(exportLayout(detail.items));
+            }}
+            renderItem={(item, actions) => (
+              <ConfigurableWidget config={item.data} onRemove={actions.removeItem} />
+            )}
+          />
+        </ContentLayout>
+      }
+      splitPanel={
+        <SplitPanel
+          header="Add widgets"
+          closeBehavior="hide"
+          hidePreferencesButton={true}
+          i18nStrings={splitPanelI18nStrings}
+        >
+          <Palette items={getPaletteWidgets(layout)} />
+        </SplitPanel>
+      }
+      splitPanelPreferences={{ position: 'side' }}
+      splitPanelOpen={splitPanelOpen}
+      onSplitPanelToggle={({ detail }) => setSplitPanelOpen(detail.open)}
+      splitPanelSize={splitPanelSize}
+      onSplitPanelResize={event => setSplitPanelSize(Math.min(event.detail.size, splitPanelMaxSize))}
+    />
   );
 }
 
 function Dashboard() {
   const { dashboardId } = useLoaderData() as { dashboardId: string };
   return (
-        <div key={dashboardId}>
-            <DashboardContent dashboardId={dashboardId}/>
-        </div>
+    <div key={dashboardId}>
+      <DashboardContent dashboardId={dashboardId}/>
+    </div>
   );
 }
 

--- a/src/pages/dashboard/widgets/chart-widget.tsx
+++ b/src/pages/dashboard/widgets/chart-widget.tsx
@@ -1,6 +1,6 @@
 import { Button, Header, Select } from '@cloudscape-design/components';
 import { IChartApi, LineData, UTCTimestamp } from 'lightweight-charts';
-import React, { Dispatch, ReactNode, SetStateAction, createContext, useContext, useEffect, useRef, useState } from 'react';
+import { Dispatch, ReactNode, SetStateAction, createContext, useContext, useEffect, useRef, useState } from 'react';
 import Chart from '../../../components/chart';
 import { useBars } from '../../../database/use-bars';
 import { updateBars } from '../../../database/use-bars/update-bars';
@@ -122,7 +122,8 @@ function WidgetHeader() {
             setIsRefreshing(false);
           }}
         />,
-      ]}>
+      ]}
+    >
       Chart
     </Header>
   );

--- a/src/pages/dashboard/widgets/interfaces.ts
+++ b/src/pages/dashboard/widgets/interfaces.ts
@@ -1,13 +1,13 @@
-import React from 'react';
+import { ReactElement, JSXElementConstructor } from 'react';
 import { BoardProps } from '@cloudscape-design/board-components/board';
 
 export interface WidgetDataType {
   title: string;
   description: string;
-  provider?: React.JSXElementConstructor<{ children: React.ReactElement }>;
-  header: React.JSXElementConstructor<Record<string, never>>;
-  content: React.JSXElementConstructor<Record<string, never>>;
-  footer?: React.JSXElementConstructor<Record<string, never>>;
+  provider?: JSXElementConstructor<{ children: ReactElement }>;
+  header: JSXElementConstructor<Record<string, never>>;
+  content: JSXElementConstructor<Record<string, never>>;
+  footer?: JSXElementConstructor<Record<string, never>>;
 }
 
 export type BoardWidgetItem = BoardProps.Item<WidgetDataType>;

--- a/src/pages/dashboard/widgets/sample-widget.tsx
+++ b/src/pages/dashboard/widgets/sample-widget.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import { useState } from 'react';
 import { Header, Table } from '@cloudscape-design/components';
 import { WidgetConfig } from './interfaces';
 import { useSubscription } from '../../../use-subscription';
@@ -11,15 +11,15 @@ function SampleContent() {
 
   return (
     <Table
-        variant='embedded'
-        items={items}
-        columnDefinitions={[
-          { id: 'ticker', header: 'Ticker', cell: item => item.ticker, width: 100 },
-          { id: 'price', header: 'Price', cell: item => item.price },
-        ]}
-        selectionType='multi'
-        onSelectionChange={({ detail }) => setSelectedTickers(new Set(detail.selectedItems.map(item => item.ticker)))}
-        selectedItems={items.filter(item => selectedTickers.has(item.ticker))}
+      variant='embedded'
+      items={items}
+      columnDefinitions={[
+        { id: 'ticker', header: 'Ticker', cell: item => item.ticker, width: 100 },
+        { id: 'price', header: 'Price', cell: item => item.price },
+      ]}
+      selectionType='multi'
+      onSelectionChange={({ detail }) => setSelectedTickers(new Set(detail.selectedItems.map(item => item.ticker)))}
+      selectedItems={items.filter(item => selectedTickers.has(item.ticker))}
     />
   );
 }

--- a/src/pages/dummy-page.tsx
+++ b/src/pages/dummy-page.tsx
@@ -1,10 +1,9 @@
-import * as React from 'react';
 
 function DummyPage() {
   return (
-        <div>
-        <h1>🚧Under construction🚧</h1>
-        </div>
+    <div>
+      <h1>🚧Under construction🚧</h1>
+    </div>
   );
 }
 

--- a/src/pages/root-layout/index.tsx
+++ b/src/pages/root-layout/index.tsx
@@ -1,4 +1,3 @@
-import * as React from 'react';
 import { AppLayout } from '@cloudscape-design/components';
 import Sidebar from '../../components/sidebar';
 import { Outlet } from 'react-router-dom';
@@ -8,21 +7,20 @@ import './index.css';
 
 function RootLayout() {
   return (
-        <>
-            <div id="top-nav">
-                <Topbar />
-            </div>
-            <AppLayout 
-                headerSelector='#top-nav'
-                navigation={<Sidebar />}
-                toolsHide={true}
-                disableContentPaddings={true}
-                content={
-                    <Outlet />
-                }
-            />
-
-        </>
+    <>
+      <div id="top-nav">
+        <Topbar />
+      </div>
+      <AppLayout
+        headerSelector='#top-nav'
+        navigation={<Sidebar />}
+        toolsHide={true}
+        disableContentPaddings={true}
+        content={
+          <Outlet />
+        }
+      />
+    </>
   );
 }
 

--- a/src/pages/ticker-overview.tsx
+++ b/src/pages/ticker-overview.tsx
@@ -1,4 +1,3 @@
-import * as React from 'react';
 import { useLoaderData, LoaderFunctionArgs } from 'react-router-dom';
 
 type Params = {


### PR DESCRIPTION
Added rules: `no-trailing-spaces`, `indent`, and `no-unused-vars`.
Disabled rules conflicting with TypeScript-specific rules.
Added plugin `plugin:react/jsx-runtime`, so the React import is no longer required.